### PR TITLE
Manual first pass of inflations for mods from SpaceDock

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,7 @@ jobs:
                   PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
                   EVENT_BEFORE: ${{ github.event.before }}
               with:
+                  game: KSP2
                   source: commits
                   pull request url: ${{ github.event.pull_request.url }}
             - name: Chmod cached files so actions/cache can read them

--- a/BetterPartsManager/BetterPartsManager-1.1.2.ckan
+++ b/BetterPartsManager/BetterPartsManager-1.1.2.ckan
@@ -1,0 +1,42 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "BetterPartsManager",
+    "name": "Better Parts Manager",
+    "abstract": "Do you hate the ingame parts manager and want a ksp 1 style parts manager? this is for you",
+    "author": "ShadowDev",
+    "version": "1.1.2",
+    "ksp_version": "0.1.0",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/214227-better-part-manager/",
+        "spacedock": "https://spacedock.info/mod/3292/Better%20Parts%20Manager",
+        "repository": "https://github.com/Bit-Studios/KerbalPartManager",
+        "bugtracker": "https://github.com/Bit-Studios/KerbalPartManager/issues",
+        "x_screenshot": "https://spacedock.info/content/ShadowDev_103785/Better_Parts_Manager/Better_Parts_Manager-1677728820.png"
+    },
+    "tags": [
+        "plugin",
+        "editor"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "kerbal_part_manager",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3292/Better%20Parts%20Manager/download/1.1.2",
+    "download_size": 10546,
+    "download_hash": {
+        "sha1": "088511F159C3B2E52CB1BDE75EC3F1395C754A06",
+        "sha256": "E15032848598420A920DA6D2F5366FA1021CA9D8FDEE2B5BF336BBD9F0E0592A"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 22066,
+    "release_date": "2023-03-13T18:22:05.429157+00:00",
+    "x_generated_by": "netkan"
+}

--- a/CheatsMenu/CheatsMenu-0.3.1.ckan
+++ b/CheatsMenu/CheatsMenu-0.3.1.ckan
@@ -1,0 +1,41 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "CheatsMenu",
+    "name": "Cheats Menu",
+    "abstract": "This mod allows you to use cheats in ksp2",
+    "author": "ShadowDev",
+    "version": "0.3.1",
+    "ksp_version": "0.1.0",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/214242-cheat-menu/",
+        "spacedock": "https://spacedock.info/mod/3266/Cheats%20Menu",
+        "repository": "https://github.com/Bit-Studios/CheatMenu",
+        "bugtracker": "https://github.com/Bit-Studios/CheatMenu/issues",
+        "x_screenshot": "https://spacedock.info/content/ShadowDev_103785/Cheats_Menu/Cheats_Menu-1677688540.png"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "cheat_menu",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3266/Cheats%20Menu/download/0.3.1",
+    "download_size": 7868,
+    "download_hash": {
+        "sha1": "288886EC4CDD149C195C14396C94EB17DED1D85B",
+        "sha256": "BDF97F88B8D5FED80EE2126AA50B1145061FF38EA97FC7C0494175C80470355B"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 15895,
+    "release_date": "2023-03-05T18:50:15.177088+00:00",
+    "x_generated_by": "netkan"
+}

--- a/CommunityFixes/CommunityFixes-0.3.1.ckan
+++ b/CommunityFixes/CommunityFixes-0.3.1.ckan
@@ -1,0 +1,44 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "CommunityFixes",
+    "name": "Community Fixes",
+    "abstract": "Community project that aims to bring together bug fixes for KSP 2",
+    "author": [
+        "ShadowDev",
+        "munix"
+    ],
+    "version": "0.3.1",
+    "ksp_version": "0.1.0",
+    "license": "MIT",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/214521-community-fixes/",
+        "spacedock": "https://spacedock.info/mod/3301/Community%20Fixes",
+        "repository": "https://github.com/Bit-Studios/CommunityFixes",
+        "bugtracker": "https://github.com/Bit-Studios/CommunityFixes/issues",
+        "x_screenshot": "https://spacedock.info/content/ShadowDev_103785/Community_Fixes/Community_Fixes-1678066194.png"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "community_fixes",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3301/Community%20Fixes/download/0.3.1",
+    "download_size": 9113,
+    "download_hash": {
+        "sha1": "96D894EE097D65A392C8181F1C51D7E12B755994",
+        "sha256": "A315E0933C0E8577A221070AAE4C85E4D0E1448B35F5FE8EFCD66044CDE21ED1"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 16467,
+    "release_date": "2023-03-13T22:03:40.197928+00:00",
+    "x_generated_by": "netkan"
+}

--- a/CustomFlags/CustomFlags-2.1.ckan
+++ b/CustomFlags/CustomFlags-2.1.ckan
@@ -1,0 +1,40 @@
+{
+    "spec_version": "v1.31",
+    "identifier": "CustomFlags",
+    "name": "Custom Flags",
+    "abstract": "Adds the ability to add custom flags",
+    "author": "adamsogm",
+    "version": "2.1",
+    "ksp_version": "0.1.0",
+    "license": "MIT",
+    "resources": {
+        "spacedock": "https://spacedock.info/mod/3262/Custom%20Flags",
+        "repository": "https://github.com/adamsong/custom-flags",
+        "bugtracker": "https://github.com/adamsong/custom-flags/issues"
+    },
+    "tags": [
+        "plugin",
+        "parts"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "custom-flags",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3262/Custom%20Flags/download/2.1",
+    "download_size": 11664,
+    "download_hash": {
+        "sha1": "A6701C7D4D6BBCD04222FEA6FA77F22D69D69EE8",
+        "sha256": "DB20908E66C6E7803F1C3FAA0725CB696F6CA000A9D34A0FABF89E74C34D3209"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 21917,
+    "release_date": "2023-03-07T00:33:58.512551+00:00",
+    "x_generated_by": "netkan"
+}

--- a/KerbalNotebook/KerbalNotebook-0.0.1.ckan
+++ b/KerbalNotebook/KerbalNotebook-0.0.1.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "KerbalNotebook",
+    "name": "Kerbal Notebook",
+    "abstract": "Take notes",
+    "author": "ShadowDev",
+    "version": "0.0.1",
+    "ksp_version": "0.1.0",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/214994-kerbal-notebook/",
+        "spacedock": "https://spacedock.info/mod/3321/Kerbal%20Notebook",
+        "x_screenshot": "https://spacedock.info/content/ShadowDev_103785/Kerbal_Notebook/Kerbal_Notebook-1678724198.png"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "notebook",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3321/Kerbal%20Notebook/download/0.0.1",
+    "download_size": 5844,
+    "download_hash": {
+        "sha1": "FD2CA2054BB0E28939DD1C1C6E5D97FEC2C56354",
+        "sha256": "5F95B7D83870429109E58CB9E381F57612AAFE39CEF32B90558631CC5FD44486"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 10770,
+    "release_date": "2023-03-13T16:16:04.734247+00:00",
+    "x_generated_by": "netkan"
+}

--- a/KerbalWebProgram/KerbalWebProgram-0.1.0.ckan
+++ b/KerbalWebProgram/KerbalWebProgram-0.1.0.ckan
@@ -1,0 +1,41 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "KerbalWebProgram",
+    "name": "Kerbal Web Program",
+    "abstract": "Control your game with Any Language [C#, JS, Java, Python]",
+    "author": "ShadowDev",
+    "version": "0.1.0",
+    "ksp_version": "0.1.0",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://github.com/Bit-Studios/KerbalWebProgram/wiki",
+        "spacedock": "https://spacedock.info/mod/3275/Kerbal%20Web%20Program",
+        "repository": "https://github.com/Bit-Studios/KerbalWebProgram",
+        "bugtracker": "https://github.com/Bit-Studios/KerbalWebProgram/issues",
+        "x_screenshot": "https://spacedock.info/content/ShadowDev_103785/Kerbal_Web_Program/Kerbal_Web_Program-1677593780.png"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "kerbal_web_program",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3275/Kerbal%20Web%20Program/download/0.1.0",
+    "download_size": 28131,
+    "download_hash": {
+        "sha1": "6168D8F3D100DCC39CEFDABD13D8E3D660DE7E38",
+        "sha256": "84C2D7CDEA27777527655008D9BD30FEEA3CF0B343A8519A843E70F214C31638"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 64718,
+    "release_date": "2023-03-11T18:33:42.594025+00:00",
+    "x_generated_by": "netkan"
+}

--- a/MoreResolutions/MoreResolutions-0.2.0.ckan
+++ b/MoreResolutions/MoreResolutions-0.2.0.ckan
@@ -1,0 +1,41 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "MoreResolutions",
+    "name": "More Resolutions",
+    "abstract": "Allows selecting non-16:9 resolutions in KSP2",
+    "author": "arthomnix",
+    "version": "0.2.0",
+    "ksp_version": "0.1.0",
+    "license": "MIT",
+    "resources": {
+        "homepage": "https://spacedock.info/mod/3320/More%2520Resolutions",
+        "spacedock": "https://spacedock.info/mod/3320/More%20Resolutions",
+        "repository": "https://github.com/arthomnix/MoreResolutions",
+        "bugtracker": "https://github.com/arthomnix/MoreResolutions/issues",
+        "x_screenshot": "https://spacedock.info/content/arthomnix_105803/More_Resolutions/More_Resolutions-1678710105.png"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "MoreResolutions",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3320/More%20Resolutions/download/0.2.0",
+    "download_size": 6612,
+    "download_hash": {
+        "sha1": "8196BB2F2243E91A28E6C55A1AD992F88B7C4874",
+        "sha256": "6F783CF0A5EF61D70ED6759CF76D64E23929C3796677F5AA6B2885A3E2CBC88A"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 13019,
+    "release_date": "2023-03-13T17:47:40.437431+00:00",
+    "x_generated_by": "netkan"
+}

--- a/PaigeBGone/PaigeBGone-1.0.0.ckan
+++ b/PaigeBGone/PaigeBGone-1.0.0.ckan
@@ -1,0 +1,37 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "PaigeBGone",
+    "name": "P.A.I.G.E B Gone",
+    "abstract": "Removes P.A.I.G.E popups and mutes her voice in KSP 2",
+    "author": "amahlaka",
+    "version": "1.0.0",
+    "license": "MIT",
+    "resources": {
+        "repository": "https://github.com/amahlaka/P.A.I.G.E-B-Gone",
+        "bugtracker": "https://github.com/amahlaka/P.A.I.G.E-B-Gone/issues"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "paige_b_gone",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://github.com/amahlaka/P.A.I.G.E-B-Gone/releases/download/1.0.0/paige_b_gone.zip",
+    "download_size": 4157,
+    "download_hash": {
+        "sha1": "834FCD12CFC5C66A943C4479003E894DA567C482",
+        "sha256": "1A6AB326DF4D54D1C0550D20B3A40191208373137D8A40D1F592F39F077C8BA0"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 7009,
+    "release_date": "2023-03-07T17:43:16Z",
+    "x_generated_by": "netkan"
+}

--- a/PartsManagerHotkey/PartsManagerHotkey-1.0.ckan
+++ b/PartsManagerHotkey/PartsManagerHotkey-1.0.ckan
@@ -1,0 +1,41 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "PartsManagerHotkey",
+    "name": "Parts Manager Hotkey",
+    "abstract": "Prevents accidentally opening Parts Manager by requiring a hotkey to be held when clicking.",
+    "author": "shdwp",
+    "version": "1.0",
+    "ksp_version": "0.1.0",
+    "license": "LGPL-3.0",
+    "resources": {
+        "homepage": "https://github.com/shdwp/ksp2PartsManagerHotkey/issues",
+        "spacedock": "https://spacedock.info/mod/3314/Parts%20Manager%20Hotkey",
+        "repository": "https://github.com/shdwp/ksp2PartsManagerHotkey",
+        "bugtracker": "https://github.com/shdwp/ksp2PartsManagerHotkey/issues"
+    },
+    "tags": [
+        "plugin",
+        "editor"
+    ],
+    "depends": [
+        {
+            "name": "BepInEx"
+        }
+    ],
+    "install": [
+        {
+            "find": "PartsManagerHotkey",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3314/Parts%20Manager%20Hotkey/download/1.0",
+    "download_size": 3207,
+    "download_hash": {
+        "sha1": "6881F82E02463D9B62019B2715107C77766117DA",
+        "sha256": "2E089919F129BC8A2AC778C09690217BEA1F22F7D1360C09E2E3DA50FC7CABDF"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 6719,
+    "release_date": "2023-03-09T19:41:21.439562+00:00",
+    "x_generated_by": "netkan"
+}

--- a/StageInfo/StageInfo-0.7.ckan
+++ b/StageInfo/StageInfo-0.7.ckan
@@ -1,0 +1,39 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "StageInfo",
+    "name": "Stage Info",
+    "abstract": "Displays thrust-to-weight ratio per stage with customizable situations",
+    "author": "natalia_simonova",
+    "version": "0.7",
+    "ksp_version": "0.1.0",
+    "license": "restricted",
+    "resources": {
+        "spacedock": "https://spacedock.info/mod/3272/Stage%20Info",
+        "x_screenshot": "https://spacedock.info/content/natalia_simonova_99724/Stage_Info/Stage_Info-1678509699.png"
+    },
+    "tags": [
+        "plugin",
+        "information"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "StageInfo",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3272/Stage%20Info/download/0.7",
+    "download_size": 322082,
+    "download_hash": {
+        "sha1": "A4058A859E839E6D31A55217FB9524225D26F5A1",
+        "sha256": "90B73AF8830ECB4573DCCEA5E3F71DF1D281F833EBEF4337D173B20DEB22EF76"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 332504,
+    "release_date": "2023-03-10T04:37:27.931878+00:00",
+    "x_generated_by": "netkan"
+}

--- a/kRPC2/kRPC2-0.1.0.ckan
+++ b/kRPC2/kRPC2-0.1.0.ckan
@@ -1,0 +1,42 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "kRPC2",
+    "name": "kRPC2",
+    "abstract": "Control the game using Python, C#, C++, Lua, Java...",
+    "author": "djungelorm",
+    "version": "0.1.0",
+    "ksp_version": "0.1.0",
+    "license": "GPL-3.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/214999-krpc2-control-the-game-using-python-c-c-java-lua/",
+        "spacedock": "https://spacedock.info/mod/3322/kRPC2",
+        "repository": "https://github.com/krpc/krpc2",
+        "bugtracker": "https://github.com/krpc/krpc2/issues"
+    },
+    "tags": [
+        "plugin",
+        "app",
+        "control"
+    ],
+    "depends": [
+        {
+            "name": "SpaceWarp"
+        }
+    ],
+    "install": [
+        {
+            "find": "kRPC2",
+            "install_to": "BepInEx/plugins"
+        }
+    ],
+    "download": "https://spacedock.info/mod/3322/kRPC2/download/0.1.0",
+    "download_size": 265919,
+    "download_hash": {
+        "sha1": "5F498658FC499A8F945E385B8232137C9D04FAFE",
+        "sha256": "BD40F6D744F3A4C93F20FE9E17D0B0FB424FA2053BE273B7BBC7BFFC8CBB2716"
+    },
+    "download_content_type": "application/zip",
+    "install_size": 676661,
+    "release_date": "2023-03-13T21:03:31.121362+00:00",
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
KSP-CKAN/KSP2-NetKAN#1 and KSP-CKAN/KSP2-NetKAN#2 added mods that were requested by their authors either directly or via SpaceDock, but the back-end isn't done (see KSP-CKAN/NetKAN-Infra#283), so they're not going to be inflated automatically yet.

However, the pull request validator was done in KSP-CKAN/xKAN-meta_testing#91 and needs to be tested for this repo, so I inflated the new netkans manually and attached the metadata here.
