### PR TITLE
Fix lost multi-host links

### DIFF
--- a/25xKerbolarSystem/25xKerbolarSystem-0.2.0.ckan
+++ b/25xKerbolarSystem/25xKerbolarSystem-0.2.0.ckan
@@ -34,7 +34,10 @@
             "install_to": "BepInEx/plugins"
         }
     ],
-    "download": "https://spacedock.info/mod/3536/2.5x%20Kerbolar%20System/download/0.2.0",
+    "download": [
+        "https://github.com/cheese3660/2.5x-Kerbolar-System/releases/download/v0.2.0/KerbolarUpscale-0.2.0.zip",
+        "https://spacedock.info/mod/3536/2.5x%20Kerbolar%20System/download/0.2.0"
+    ],
     "download_size": 4205,
     "download_hash": {
         "sha1": "BE85CB9794D40CE2C8C81BC36E415D72E22E141C",

--- a/FlightPlan/FlightPlan-0.10.2.ckan
+++ b/FlightPlan/FlightPlan-0.10.2.ckan
@@ -39,7 +39,10 @@
             "filter_regexp": "\\.pdb$"
         }
     ],
-    "download": "https://spacedock.info/mod/3359/Flight%20Plan/download/0.10.2",
+    "download": [
+        "https://github.com/schlosrat/FlightPlan/releases/download/0.10.2/flight_plan-0.10.2.zip",
+        "https://spacedock.info/mod/3359/Flight%20Plan/download/0.10.2"
+    ],
     "download_size": 48033919,
     "download_hash": {
         "sha1": "0BBDC9A7D9FB356D139FF7FCE5D0E4009BA91DA7",

--- a/SPARKTechnologies/SPARKTechnologies-0.1.4.1.ckan
+++ b/SPARKTechnologies/SPARKTechnologies-0.1.4.1.ckan
@@ -29,7 +29,10 @@
             "install_to": "BepInEx/plugins"
         }
     ],
-    "download": "https://github.com/schlosrat/SPARK/releases/download/0.1.4.1/SPARK_0.1.4.1.zip",
+    "download": [
+        "https://github.com/schlosrat/SPARK/releases/download/0.1.4.1/SPARK_0.1.4.1.zip",
+        "https://spacedock.info/mod/3470/SPARK%20Technologies/download/0.1.4.1"
+    ],
     "download_size": 96933382,
     "download_hash": {
         "sha1": "2318A924377C352D935E60CBA25015EFDBC31E5B",

--- a/ScienceArkive/ScienceArkive-0.5.0.ckan
+++ b/ScienceArkive/ScienceArkive-0.5.0.ckan
@@ -33,7 +33,10 @@
             "install_to": "BepInEx/plugins"
         }
     ],
-    "download": "https://spacedock.info/mod/3541/Science%20Arkive/download/0.5.0",
+    "download": [
+        "https://github.com/Kerbalight/ScienceArkive/releases/download/v0.5.0/ScienceArkive-0.5.0.zip",
+        "https://spacedock.info/mod/3541/Science%20Arkive/download/0.5.0"
+    ],
     "download_size": 196333,
     "download_hash": {
         "sha1": "E394EDB3B59296BE6E2A0D2AA44AB4F28421F557",

--- a/TheNuclearOption/TheNuclearOption-0.3.0.ckan
+++ b/TheNuclearOption/TheNuclearOption-0.3.0.ckan
@@ -26,7 +26,10 @@
             "install_to": "BepInEx/plugins"
         }
     ],
-    "download": "https://github.com/schlosrat/TNO/releases/download/0.3.0/TNO_0.3.0.zip",
+    "download": [
+        "https://github.com/schlosrat/TNO/releases/download/0.3.0/TNO_0.3.0.zip",
+        "https://spacedock.info/mod/3471/The%20Nuclear%20Option/download/0.3.0"
+    ],
     "download_size": 30086186,
     "download_hash": {
         "sha1": "806E11F7B25C31679A7ADDB124A544C8276A5D67",


### PR DESCRIPTION
Some multi-hosted mods lost a download link on a previous release because the bot ran when only one host was updated with a new release. Now these changes are reverted. We'll probably want an automated fix for this at some point, but for now this should suffice.
